### PR TITLE
Fix inserting referenced entities when enabling OrientDB batch insert

### DIFF
--- a/rxrepo-core/src/main/java/com/slimgears/rxrepo/query/decorator/UpdateReferencesFirstQueryProviderDecorator.java
+++ b/rxrepo-core/src/main/java/com/slimgears/rxrepo/query/decorator/UpdateReferencesFirstQueryProviderDecorator.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 public class UpdateReferencesFirstQueryProviderDecorator extends AbstractQueryProviderDecorator {
     private final static Logger log = LoggerFactory.getLogger(UpdateReferencesFirstQueryProviderDecorator.class);
 
-    private UpdateReferencesFirstQueryProviderDecorator(QueryProvider underlyingProvider) {
+    protected UpdateReferencesFirstQueryProviderDecorator(QueryProvider underlyingProvider) {
         super(underlyingProvider);
     }
 

--- a/rxrepo-orientdb/src/main/java/com/slimgears/rxrepo/orientdb/OrientDbRepository.java
+++ b/rxrepo-orientdb/src/main/java/com/slimgears/rxrepo/orientdb/OrientDbRepository.java
@@ -136,7 +136,7 @@ public class OrientDbRepository {
                     .decorate(
                             RecursiveLiveQueryProviderDecorator.create(),
                             LiveQueryProviderDecorator.create(),
-                            batchSupport ? QueryProvider.Decorator.identity() : UpdateReferencesFirstQueryProviderDecorator.create(),
+                            batchSupport ? OrientDbUpdateReferencesFirstQueryProviderDecorator.create() : UpdateReferencesFirstQueryProviderDecorator.create(),
                             OrientDbDropDatabaseQueryProviderDecorator.create(dbClient, dbName),
                             decorator)
                     .buildRepository(configBuilder.build())

--- a/rxrepo-orientdb/src/main/java/com/slimgears/rxrepo/orientdb/OrientDbUpdateReferencesFirstQueryProviderDecorator.java
+++ b/rxrepo-orientdb/src/main/java/com/slimgears/rxrepo/orientdb/OrientDbUpdateReferencesFirstQueryProviderDecorator.java
@@ -1,0 +1,24 @@
+package com.slimgears.rxrepo.orientdb;
+
+import com.slimgears.rxrepo.query.decorator.UpdateReferencesFirstQueryProviderDecorator;
+import com.slimgears.rxrepo.query.provider.QueryProvider;
+import com.slimgears.util.autovalue.annotations.MetaClassWithKey;
+import io.reactivex.Completable;
+
+public class OrientDbUpdateReferencesFirstQueryProviderDecorator extends UpdateReferencesFirstQueryProviderDecorator {
+    private final QueryProvider underlyingProvider;
+
+    private OrientDbUpdateReferencesFirstQueryProviderDecorator(QueryProvider underlyingProvider) {
+        super(underlyingProvider);
+        this.underlyingProvider = underlyingProvider;
+    }
+
+    public static Decorator create() {
+        return OrientDbUpdateReferencesFirstQueryProviderDecorator::new;
+    }
+
+    @Override
+    public <K, S> Completable insert(MetaClassWithKey<K, S> metaClass, Iterable<S> entities) {
+        return underlyingProvider.insert(metaClass, entities);
+    }
+}

--- a/rxrepo-test/src/main/java/com/slimgears/rxrepo/test/AbstractRepositoryTest.java
+++ b/rxrepo-test/src/main/java/com/slimgears/rxrepo/test/AbstractRepositoryTest.java
@@ -120,6 +120,28 @@ public abstract class AbstractRepositoryTest {
     }
 
     @Test
+    public void testUpdateReferencedEntity() throws InterruptedException {
+        EntitySet<UniqueId, Product> productSet = repository.entities(Product.metaClass);
+        Product product = Product.builder()
+                .name("Product 1")
+                .key(UniqueId.productId(1))
+                .price(1001)
+                .build();
+
+        productSet.update(product).test().await().assertNoErrors();
+        product = productSet.query().where(Product.$.key.eq(UniqueId.productId(1))).first().blockingGet();
+        Assert.assertNull(product.inventory());
+        Inventory inventory = Inventory.builder()
+                .id(UniqueId.inventoryId(1))
+                .name("Inventory 1")
+                .build();
+        Product updatedProduct = product.toBuilder().inventory(inventory).build();
+        productSet.update(updatedProduct).test().await().assertNoErrors();
+        product = productSet.query().where(Product.$.key.eq(UniqueId.productId(1))).first().blockingGet();
+        Assert.assertNotNull(product.inventory());
+    }
+
+    @Test
     public void testAddAlreadyExistingObject() throws InterruptedException {
         EntitySet<UniqueId, Product> productSet = repository.entities(Product.metaClass);
         Product product = Product.builder()


### PR DESCRIPTION
When updating an existing entity that had null reference to another entity the referenced entity did not get insert.
Test for this scenario has been added.