### PR TITLE
Buffer entities on batch insert for optimal insertion time

### DIFF
--- a/rxrepo-orientdb/src/main/java/com/slimgears/rxrepo/orientdb/OrientDbQueryProvider.java
+++ b/rxrepo-orientdb/src/main/java/com/slimgears/rxrepo/orientdb/OrientDbQueryProvider.java
@@ -19,6 +19,7 @@ import com.slimgears.util.autovalue.annotations.MetaClassWithKey;
 import com.slimgears.util.stream.Optionals;
 import com.slimgears.util.stream.Streams;
 import io.reactivex.Completable;
+import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,25 +32,29 @@ import java.util.stream.Collectors;
 public class OrientDbQueryProvider extends SqlQueryProvider {
     private final static Logger log = LoggerFactory.getLogger(OrientDbQueryProvider.class);
     private final OrientDbSessionProvider dbSessionProvider;
+    private final int bufferSize;
 
     OrientDbQueryProvider(SqlStatementProvider statementProvider,
                           SqlStatementExecutor statementExecutor,
                           SchemaProvider schemaProvider,
                           ReferenceResolver referenceResolver,
                           ExecutorPool executorPool,
-                          OrientDbSessionProvider dbSessionProvider) {
+                          OrientDbSessionProvider dbSessionProvider,
+                          int bufferSize) {
         super(statementProvider, statementExecutor, schemaProvider, referenceResolver, executorPool);
         this.dbSessionProvider = dbSessionProvider;
+        this.bufferSize = bufferSize;
     }
 
-    static OrientDbQueryProvider create(SqlServiceFactory serviceFactory, OrientDbSessionProvider sessionProvider) {
+    static OrientDbQueryProvider create(SqlServiceFactory serviceFactory, OrientDbSessionProvider sessionProvider, int bufferSize) {
         return new OrientDbQueryProvider(
                 serviceFactory.statementProvider(),
                 serviceFactory.statementExecutor(),
                 serviceFactory.schemaProvider(),
                 serviceFactory.referenceResolver(),
                 serviceFactory.executorPool(),
-                sessionProvider);
+                sessionProvider,
+                bufferSize);
     }
 
     @Override
@@ -60,7 +65,9 @@ public class OrientDbQueryProvider extends SqlQueryProvider {
 
         Stopwatch stopwatch = Stopwatch.createStarted();
         return schemaProvider.createOrUpdate(metaClass)
-                .andThen(Completable.fromAction(() -> createAndSaveElements(entities)))
+                .andThen(Observable.fromIterable(entities)
+                        .buffer(bufferSize)
+                        .concatMapCompletable(buffer -> Completable.fromAction(() -> createAndSaveElements(buffer))))
                 .doOnComplete(() -> log.debug("Total insert time: {}s", stopwatch.elapsed(TimeUnit.SECONDS)));
     }
 

--- a/rxrepo-orientdb/src/main/java/com/slimgears/rxrepo/orientdb/OrientDbRepository.java
+++ b/rxrepo-orientdb/src/main/java/com/slimgears/rxrepo/orientdb/OrientDbRepository.java
@@ -48,6 +48,7 @@ public class OrientDbRepository {
         private String serverUser = "root";
         private String serverPassword = "root";
         private boolean batchSupport = false;
+        private int batchBufferSize = 20000;
         private int maxNotificationQueues = 10;
         private QueryProvider.Decorator decorator = QueryProvider.Decorator.identity();
         private RepositoryConfig.Builder configBuilder = RepositoryConfig
@@ -63,6 +64,12 @@ public class OrientDbRepository {
 
         public final Builder enableBatchSupport(boolean enable) {
             this.batchSupport = enable;
+            return this;
+        }
+
+        public final Builder enableBatchSupport(boolean enable, int bufferSize) {
+            this.batchSupport = enable;
+            this.batchBufferSize = bufferSize;
             return this;
         }
 
@@ -194,7 +201,7 @@ public class OrientDbRepository {
                     .assignmentGenerator(svc -> new OrientDbAssignmentGenerator(svc.expressionGenerator()))
                     .statementProvider(svc -> new DefaultSqlStatementProvider(svc.expressionGenerator(), svc.assignmentGenerator(), svc.schemaProvider()))
                     .referenceResolver(svc -> new OrientDbReferenceResolver(svc.statementProvider()))
-                    .queryProviderGenerator(svc -> batchSupport ? OrientDbQueryProvider.create(svc, dbSessionProvider) : SqlQueryProvider.create(svc));
+                    .queryProviderGenerator(svc -> batchSupport ? OrientDbQueryProvider.create(svc, dbSessionProvider, batchBufferSize) : SqlQueryProvider.create(svc));
         }
     }
 }


### PR DESCRIPTION
Testing with verious counts of batch inserts (1K-70K) shows that inserting batches of ~20K is faster than larger buffers.